### PR TITLE
Fixed Chiru Labs Simple PBT Example's link

### DIFF
--- a/pages/Examples/smart-contracts.md
+++ b/pages/Examples/smart-contracts.md
@@ -4,7 +4,7 @@ As secp256k1 ECDSA signers, HaLo signatures can easily be verified in smart cont
 
 ## Ethereum
 
-- [Chiru Labs Simple PBT Example](https://github.com/chiru-labs/PBT/blob/main/src/PBTSimple.sol) 
+- [Chiru Labs Simple PBT Example](https://github.com/chiru-labs/PBT/blob/main/src/v2/PBTSimple.sol) 
 
 An EIP-191 compatible signature from a HaLo chip is used to claim ownership of a PBT or "physically-backed token". The PBT example does not currently integrate LibHaLo for capturing signatures, which we would recommend as LibHaLo will can directly produce EIP-191 prefixed signatures.
 


### PR DESCRIPTION
The link was broken because the original repository created two versions of `PBTSimple.sol`, v1 and v2. Here I have included the v2 version!